### PR TITLE
API 에 JWT 로직 추가.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@workday/canvas-kit-react": "^11.0.11",
         "axios": "^1.7.2",
         "date-fns": "^3.6.0",
+        "js-cookie": "^3.0.5",
         "qs": "^6.12.2",
         "react": "^18.3.1",
         "react-datepicker": "^7.2.0",
@@ -12982,6 +12983,15 @@
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@workday/canvas-kit-react": "^11.0.11",
     "axios": "^1.7.2",
     "date-fns": "^3.6.0",
+    "js-cookie": "^3.0.5",
     "qs": "^6.12.2",
     "react": "^18.3.1",
     "react-datepicker": "^7.2.0",

--- a/src/Axios/ExperienceApi.js
+++ b/src/Axios/ExperienceApi.js
@@ -1,4 +1,5 @@
-import axios from "axios";
+// import axios from "axios";
+import api from './axiosConfig.mjs';
 
 const server = process.env.REACT_APP_DEV_URL;
 
@@ -6,7 +7,7 @@ const server = process.env.REACT_APP_DEV_URL;
 export const postExperienceAPI = async (data) => {
   console.log(data);
   try {
-    const response = await axios.post(`${server}experiences`, data);
+    const response = await api.post(`${server}experiences`, data);
     console.log(response.status);
     return response;
   } catch (error) {
@@ -18,7 +19,7 @@ export const postExperienceAPI = async (data) => {
 export const getOneExperienceAPI = async (expId) => {
   console.log(expId);
   try {
-    const response = await axios.get(`${server}experiences/${expId}`);
+    const response = await api.get(`${server}experiences/${expId}`);
     if (response.data.success) {
       console.log(response.data.response_object);
     } else {
@@ -35,7 +36,7 @@ export const getOneExperienceAPI = async (expId) => {
 export const deleteOneExperienceAPI = async (expId, user_id) => {
     console.log(`Attempting to delete experience with ID: ${expId} for user ID: ${user_id}`);
     try {
-      const response = await axios.delete(`${server}experiences/${expId}`, {
+      const response = await api.delete(`${server}experiences/${expId}`, {
         data: { user_id }
       });
       console.log('Delete successful:', response.data);
@@ -62,7 +63,7 @@ export const deleteOneExperienceAPI = async (expId, user_id) => {
 // 경험 기록 수정 API
 export const editOneExpereienceAPI = async (id = 10, data) => {
   try {
-    const response = await axios.put(`${server}experiences/${id}`, data);
+    const response = await api.put(`${server}experiences/${id}`, data);
     console.log(response.data);
   } catch (error) {
     console.error(error);

--- a/src/Axios/ProjectDataApi.js
+++ b/src/Axios/ProjectDataApi.js
@@ -1,11 +1,12 @@
-import axios from 'axios'
+// import axios from 'axios'
+import api from './axiosConfig.mjs';
 import qs from 'qs';
 
 // 유저의 모든 프로젝트 데이터를 받아옴
 export const getUserProjectDataAPI = async (id) => {
 
     try {
-        const response = await axios.get(`${process.env.REACT_APP_DEV_URL}projects/list/${id}`);
+        const response = await api.get(`${process.env.REACT_APP_DEV_URL}projects/list/${id}`);
         console.log(response.data)
         return response.data
     } catch (error) {
@@ -19,7 +20,7 @@ export const getUserProjectDataAPI = async (id) => {
 export const getOneProjectDataAPI = async (userData) => {
     console.log(userData);
     try {
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}projects/${userData.project_id}`,
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}projects/${userData.project_id}`,
             {
                 user_id: userData.user_id
             });
@@ -35,7 +36,7 @@ export const getOneProjectDataAPI = async (userData) => {
 export const getUserProjectDataFilteredAPI = async (filter) => {
     console.log(filter);
     try {
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}projects/search`, filter);
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}projects/search`, filter);
         console.log(response.data.response_object)
         return response.data.response_object
     } catch (error) {
@@ -48,7 +49,7 @@ export const getUserProjectDataFilteredAPI = async (filter) => {
 export const postNewProjectAPI = async (data) => {
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}projects`);
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}projects`, data);
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}projects`, data);
         console.log(response.data)
         return response.data
     } catch (error) {
@@ -65,7 +66,7 @@ export const postNewProjectImageAPI = async (formData, project_id) => {
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}s3/${project_id}`);
         console.log(formData);
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}s3/${project_id}`, formData
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}s3/${project_id}`, formData
             , {
                 headers: {
                     'Content-Type': 'multipart/form-data'
@@ -83,7 +84,7 @@ export const postNewProjectImageAPI = async (formData, project_id) => {
 export const updateProjectAPI = async (project_id, data) => {
     try {
         console.log(data);
-        const response = await axios.put(`${process.env.REACT_APP_DEV_URL}projects/${project_id}`, data);
+        const response = await api.put(`${process.env.REACT_APP_DEV_URL}projects/${project_id}`, data);
         console.log(response.data)
         return response.data
     } catch (error) {
@@ -95,7 +96,7 @@ export const updateProjectAPI = async (project_id, data) => {
 export const deleteProjectAPI = async (data) => {
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}projects/${data.project_id}`, data.user_id);
-        const response = await axios.delete(`${process.env.REACT_APP_DEV_URL}projects/${data.project_id}`, {
+        const response = await api.delete(`${process.env.REACT_APP_DEV_URL}projects/${data.project_id}`, {
             data: {
                 user_id: data.user_id
             }
@@ -113,7 +114,7 @@ export const getUserExperienceDataFilteredAPI = async (filter) => {
     console.log(filter);
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}experiences/search`);
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}experiences/search`, filter);
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}experiences/search`, filter);
         console.log(response.data.response_object)
         return response.data.response_object
     } catch (error) {
@@ -126,7 +127,7 @@ export const getUserExperienceDataAPI = async (userKey) => {
     console.log(userKey);
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}experiences/project`);
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}experiences/project`, userKey);
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}experiences/project`, userKey);
         console.log(response.data.response_object)
         return response.data.response_object
     } catch (error) {
@@ -139,7 +140,7 @@ export const restartProjectAPI = async (projectData) => {
     console.log(projectData.user_id);
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}projects/resume/${projectData.project_id}`);
-        const response = await axios.put(`${process.env.REACT_APP_DEV_URL}projects/resume/${projectData.project_id}`, {
+        const response = await api.put(`${process.env.REACT_APP_DEV_URL}projects/resume/${projectData.project_id}`, {
             user_id: projectData.user_id
         });
         console.log(response.data)
@@ -154,7 +155,7 @@ export const putProjectTagAPI = async (projectData, data) => {
     console.log(projectData.user_id);
     try {
         console.log(`${process.env.REACT_APP_DEV_URL}projects/finish/${projectData.project_id}`);
-        const response = await axios.put(`${process.env.REACT_APP_DEV_URL}projects/finish/${projectData.project_id}`, {
+        const response = await api.put(`${process.env.REACT_APP_DEV_URL}projects/finish/${projectData.project_id}`, {
             user_id: projectData.user_id
             , competency_tag_ids: data
         });
@@ -167,7 +168,7 @@ export const putProjectTagAPI = async (projectData, data) => {
 }
 export const getAllLink = async (data) => {
     try {
-        const response = await axios.post(`${process.env.REACT_APP_DEV_URL}projects/reference`, data);
+        const response = await api.post(`${process.env.REACT_APP_DEV_URL}projects/reference`, data);
         console.log(response.data);
         return response.data;
     } catch (error) {

--- a/src/Axios/ReferenceApi.js
+++ b/src/Axios/ReferenceApi.js
@@ -1,4 +1,5 @@
-import axios from "axios";
+// import axios from "axios";
+import api from './axiosConfig.mjs';
 
 const server = process.env.REACT_APP_DEV_URL;
 
@@ -9,7 +10,7 @@ export const getUrlMetaData = async (url) => {
   const encodedUrl = encodeURIComponent(url);
   console.log(encodedUrl);
   try {
-    const response = await axios.post(`${server}reference`, { url: encodedUrl });
+    const response = await api.post(`${server}reference`, { url: encodedUrl });
     // const response = await axios.get(`${server}reference/get`, {
     //   params: { url: url },
     // });

--- a/src/Axios/RegisterApi.js
+++ b/src/Axios/RegisterApi.js
@@ -1,4 +1,5 @@
-import axios from 'axios'
+// import axios from 'axios'
+import api from './axiosConfig.mjs';
 import qs from 'qs';
 
 // 유저의 모든 프로젝트 데이터를 받아옴
@@ -6,7 +7,7 @@ export const registerUserAPI = async (loginData) => {
 
     try {
         console.log(loginData)
-        const response = await axios.put(`${process.env.REACT_APP_DEV_URL}user/register`, loginData);
+        const response = await api.put(`${process.env.REACT_APP_DEV_URL}user/register`, loginData);
         console.log(response.data)
         return response.data
     } catch (error) {

--- a/src/Axios/StoredTagInfoApi.js
+++ b/src/Axios/StoredTagInfoApi.js
@@ -1,4 +1,5 @@
-import axios from "axios";
+// import axios from "axios";
+import api from './axiosConfig.mjs';
 
 const server = process.env.REACT_APP_DEV_URL;
 
@@ -7,7 +8,7 @@ export const getAllTagAndQuestionAPI = async () => {
     const requestUrl = `${server}question/get`;
     console.log (requestUrl);
   try {
-    const response = await axios.get(requestUrl);
+    const response = await api.get(requestUrl);
     console.log (response.data);
     return response.data;
   } catch (error) {

--- a/src/Axios/axiosConfig.mjs
+++ b/src/Axios/axiosConfig.mjs
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import Cookies from 'js-cookie';
+
+const api = axios.create({
+    baseURL: process.env.REACT_APP_API_BASE_URL,
+    withCredentials: true,
+});
+
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+const subscribeTokenRefresh = (cb) => {
+    refreshSubscribers.push(cb);
+};
+
+const onRefreshed = (token) => {
+    refreshSubscribers.map((cb) => cb(token));
+};
+
+const refreshToken = async () => {
+    try {
+        await api.post(`${process.env.REACT_APP_DEV_URL}auth/refresh`);
+    } catch (err) {
+        console.error('Refresh token request failed', err);
+        Cookies.remove('access_token');
+        Cookies.remove('refresh_token');
+        // window.location.href = '/login';
+        return Promise.reject(err);
+    }
+};
+
+api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+
+        if (error.response.status === 401 && !originalRequest._retry) {
+            if (!isRefreshing) {
+                isRefreshing = true;
+                originalRequest._retry = true;
+
+                try {
+                    const newAccessToken = await refreshToken();
+                    isRefreshing = false;
+                    onRefreshed(newAccessToken);
+                    originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+                    return api(originalRequest);
+                } catch (err) {
+                    isRefreshing = false;
+                    return Promise.reject(err);
+                }
+            }
+
+            const retryOriginalRequest = new Promise((resolve) => {
+                subscribeTokenRefresh((token) => {
+                    originalRequest.headers.Authorization = `Bearer ${token}`;
+                    resolve(api(originalRequest));
+                });
+            });
+
+            return retryOriginalRequest;
+        }
+
+        return Promise.reject(error);
+    }
+);
+
+export default api;

--- a/src/Pages/Home/Components/LoginButton.js
+++ b/src/Pages/Home/Components/LoginButton.js
@@ -3,11 +3,13 @@ import { useGoogleLogin } from "@react-oauth/google";
 import { useNavigate } from "react-router-dom";
 import { ReactComponent as GoogleLogo } from "../../../Assets/GoogleLogo.svg"
 import axios from 'axios'
+import api from '../../../Axios/axiosConfig.mjs';
 import { useRecoilState } from "recoil";
 import { isLogined, recoilLoginData, recoilUserData, recoilUserExperienceFilter, recoilUserProjectFilter } from "../../../Atom/UserDataAtom";
 import { experienceState } from "../../../Atom/ExpRecordAtom";
 import { useState, useEffect } from "react";
 import RegisterModal from "./RegisterModal";
+import Cookies from 'js-cookie';
 
 const LoginButton = ({ buttonText, buttonWidth, buttonColor }) => {
 
@@ -83,7 +85,7 @@ const LoginButton = ({ buttonText, buttonWidth, buttonColor }) => {
             const jsonUserData = JSON.stringify(userData);
             console.log(`${process.env.REACT_APP_DEV_URL}auth/login`);
             console.log(jsonUserData);
-            const response = await axios.post(
+            const response = await api.post(
                 `${process.env.REACT_APP_DEV_URL}auth/login`,
                 jsonUserData,
                 {
@@ -93,6 +95,10 @@ const LoginButton = ({ buttonText, buttonWidth, buttonColor }) => {
                 }
             );
             console.log("서버 응답2:", response.data);
+            // 쿠키에 토큰이 제대로 설정되는지 확인
+            console.log('Access Token:', Cookies.get('access_token'));
+            console.log('Refresh Token:', Cookies.get('refresh_token'));
+
             setIsNewUser(response.data.is_new_user);
             // console.log(userData1);
             setLoginData(userData);


### PR DESCRIPTION
# JWT를 사용하는 서버에 API를 보내는 리액트 예제를 적용.

1. `login` 시 `access_token`과 `refresh_token`을 발급받음 (쿠키에 자동저장됨)
2. 예시로 `get`을 함 (`token` 인증 없이는 `get` 불가한 API에 요청)
3. `access_token`이 유효하다면 `get` 성공
4. `access_token`이 유효하지 않다면, `refresh_token`을 이용한 새 `access_token`을 발급받는 API를 요청.
   (쿠키는 유효기간 지날 시 자동으로 사라짐)
5. `refresh_token`이 유효하다면, 서버로부터 `access_token`을 발급받음 (쿠키에 자동저장됨)
6. `refresh_token`이 유효하지 않다면, `login` 화면으로 되돌아감.
👉🏻 현재 로그인 화면으로 돌아가는 것은 해두지 않았습니다. 
👉🏻 코드에서 루트경로 `/` 로 돌려보내면 될 듯 하다만, 프런트님들이 해주세요! 정확한 구현을 위해 ㅎㅎ

참고 링크 [React_JWT_sample_code](https://github.com/Callein/React_JWT_sample_code)

